### PR TITLE
feat: legacy bucket support

### DIFF
--- a/aws/bucket/main.tf
+++ b/aws/bucket/main.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "access" {
 
 
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${format("uw-%s-%s-%s", replace(var.team, "/^uw-/", ""), var.name, var.env)}"
+  bucket = "${replace(var.preformatted_bucket_name, "LEGACY_BUCKET", format("uw-%s-%s-%s", replace(var.team, "/^uw-/", ""), var.name, var.env))}"
   acl = "private"
   policy = "${data.aws_iam_policy_document.access.json}"
   tags {

--- a/aws/bucket/vars.tf
+++ b/aws/bucket/vars.tf
@@ -24,3 +24,8 @@ variable "list_access" {
   default = ""
   description = "arns with list content access"
 }
+
+variable "preformatted_bucket_name" {
+  description = "the leagacy bucket name"
+  default = "LEGACY_BUCKET"
+}


### PR DESCRIPTION
provides a variable to override bucket name with a legacy
bucket name via `preformatted_bucket_name`